### PR TITLE
Upgrade samples to latest SDK.

### DIFF
--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/Directory.Build.targets
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/Directory.Build.targets
@@ -2,7 +2,7 @@
 <Project>
 
   <ItemGroup Condition="'$(UseDesignerSDK)' == 'true'">
-    <PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.1.0-prerelease-preview3.22076.5" />
+    <PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.6.0" />
   </ItemGroup>
 
 </Project>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.ClientServerProtocol/TileRepeater.ClientServerProtocol.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.ClientServerProtocol/TileRepeater.ClientServerProtocol.csproj
@@ -3,12 +3,10 @@
   <PropertyGroup>
     <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
     <UseWindowsForms>true</UseWindowsForms>
-	<LangVersion>9.0</LangVersion>
-	<Nullable>enable</Nullable>
+	  <LangVersion>10.0</LangVersion>
+	  <Nullable>enable</Nullable>
+    
+    <UseDesignerSDK>true</UseDesignerSDK>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.1.0-prerelease-preview3.22076.5" />
-  </ItemGroup>
 
 </Project>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Controls/TileRepeater.Controls.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Controls/TileRepeater.Controls.csproj
@@ -6,4 +6,5 @@
     <UseWindowsForms>true</UseWindowsForms>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+  
 </Project>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Client/TileRepeater.Designer.Client.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Client/TileRepeater.Designer.Client.csproj
@@ -5,13 +5,11 @@
 		<UseWindowsForms>true</UseWindowsForms>
 		<LangVersion>9.0</LangVersion>
 		<Nullable>enable</Nullable>
-	</PropertyGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.1.0-prerelease-preview3.22076.5" />
-	</ItemGroup>
+    <UseDesignerSDK>true</UseDesignerSDK>
+  </PropertyGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\TileRepeater.ClientServerProtocol\TileRepeater.ClientServerProtocol.csproj" />
 	</ItemGroup>
+  
 </Project>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Client/TypeRoutingProvider.cs
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Client/TypeRoutingProvider.cs
@@ -1,4 +1,14 @@
-﻿using Microsoft.DotNet.DesignTools.Client.TypeRouting;
+﻿// Note: Here we have a 2nd lookup table that works in reverse for server-side operations:
+// This table is essential when the server needs to call a Type-Editor for a control.
+// In this scenario, the UI runs within the context of Visual Studio, not the server.
+// The type routing for this is defined on the client-side because the Type-Editor should
+// only exist there, matching the target framework of Visual Studio.
+// So, when the server needs the Type-Editor, it asks the client-side,
+// "Give me the editor type for control X." The client uses this lookup table to find
+// the correct editor type. This way, the server requests what editor type to use,
+// even though that type only exists in the Visual Studio context.
+
+using Microsoft.DotNet.DesignTools.Client.TypeRouting;
 using System.Collections.Generic;
 using WinForms.Tiles.Designer.Protocol;
 

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Server/TileRepeater.Designer.Server.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Server/TileRepeater.Designer.Server.csproj
@@ -4,11 +4,8 @@
 		<TargetFramework>net6.0-windows</TargetFramework>
 		<UseWindowsForms>true</UseWindowsForms>
 		<Nullable>enable</Nullable>
-	</PropertyGroup>
-
-	<ItemGroup>
-	  <PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.1.0-prerelease-preview3.22076.5" />
-	</ItemGroup>
+    <UseDesignerSDK>true</UseDesignerSDK>
+  </PropertyGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\TileRepeater.ClientServerProtocol\TileRepeater.ClientServerProtocol.csproj" />

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Server/TypeRoutingProvider.cs
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Designer.Server/TypeRoutingProvider.cs
@@ -1,24 +1,31 @@
-﻿// Note: We need a TypeRoutineProvider ONLY in those cases,
-// where we need to have User-Interaction direct on the Design Surface and inside the control,
-// for example where it is the case with the SplitterControl. In that case, for certain operations,
-// we need to have an assignment from the actual control Designer to a ControlDesignerProxy, which would
-// do the respective UI-Interaction with the User in the Context of the client.
+﻿// Note: We need the server-side TypeRoutingProvider to enable type resolution for the designer
+// in Visual Studio (client-side). On the client-side, we identify the designer for each control
+// that the root designer (the designer of the Form or UserControl) is hosting.
+// On the client-side, this will be a ComponentProxy, not the actual custom control,
+// since the real control resides on the server-side, as does its designer.
+// Therefore, on the client-side, we only know the type as a string; the actual type doesn't exist.
+// This provider links the name to the actual type. The name "TileRepeater" is atop our control.
+// Since it's a string and not a real type, we can read it on the client-side but not fully understand it.
+// We can, however, ask the server to "give us the ProxyObject for the designer named 'TileRepeaterDesigner'."
+// The server then uses a lookup table, finds the actual type, creates an ObjectProxy,
+// and returns a type descriptor with that proxy (pointing to the real type on the server) back to
+// the client-side designer.
 
-//using Microsoft.DotNet.DesignTools.TypeRouting;
-//using System.Collections.Generic;
+using Microsoft.DotNet.DesignTools.TypeRouting;
+using System.Collections.Generic;
 
-//namespace WinForms.Tiles.Designer.Server
-//{
-//    [ExportTypeRoutingDefinitionProvider]
-//    internal class TypeRoutingProvider : TypeRoutingDefinitionProvider
-//    {
-//        public override IEnumerable<TypeRoutingDefinition> GetDefinitions()
-//            => new[]
-//            {
-//                new TypeRoutingDefinition(
-//                    TypeRoutingKinds.Designer, 
-//                    nameof(TileRepeaterDesignerProxy), 
-//                    typeof(TileRepeaterDesignerProxy))
-//            };
-//    }
-//}
+namespace WinForms.Tiles.Designer.Server
+{
+    [ExportTypeRoutingDefinitionProvider]
+    internal class TypeRoutingProvider : TypeRoutingDefinitionProvider
+    {
+        public override IEnumerable<TypeRoutingDefinition> GetDefinitions()
+            => new[]
+            {
+                new TypeRoutingDefinition(
+                    TypeRoutingKinds.Designer,
+                    nameof(TileRepeaterDesigner),
+                    typeof(TileRepeaterDesigner))
+            };
+    }
+}

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeaterDemo/TileRepeaterDemo.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeaterDemo/TileRepeaterDemo.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="TileRepeater.Package" Version="*" />
   </ItemGroup>
 
-	<ItemGroup>
-	  <ProjectReference Include="..\TileRepeater.Data\TileRepeater.Data.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\TileRepeater.Data\TileRepeater.Data.csproj" />
+  </ItemGroup>
 </Project>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Simplified/TileRepeater.Controls.Simplified/TileRepeater.Controls.Simplified.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Simplified/TileRepeater.Controls.Simplified/TileRepeater.Controls.Simplified.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.1.0-prerelease-preview3.22076.5" />
+		<PackageReference Include="Microsoft.WinForms.Designer.SDK" Version="1.6.0" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
* Remove the hard-coded NuGet Package Version, so that the `Directory.Build.Targets` can be picked up.
* Fix references accordingly.
* Update descriptions for the Type-Routing Provider purposes.
