### PR TITLE
Correct NuGet.Config issues.

### DIFF
--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/Directory.Build.targets
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/Directory.Build.targets
@@ -6,7 +6,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(UseTileRepeater)' == 'true'">
-    <PackageReference Include="TileRepeater.Package"/>
+    <PackageReference Include="TileRepeater.Package" Version="*"/>
   </ItemGroup>
 
 </Project>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/NuGet.config
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/NuGet.config
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <packageSources>
+    <clear/>
     <add key="WinFormsSdk" value=".\NuGet\BuildOut" />
   </packageSources>
   <disabledPackageSources />
@@ -8,5 +9,12 @@
     <packageSource key="WinFormsSdk">
       <package pattern="TileRepeater.Package*" />
     </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*"  />
+    </packageSource>
+    <packageSource key="Local Nuget Feed">
+      <package pattern="*" />
+    </packageSource>
   </packageSourceMapping>
+
 </configuration>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Data/TileRepeater.Data.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeater.Data/TileRepeater.Data.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
     <PackageReference Include="MetadataExtractor" Version="2.7.2" />
     <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
   </ItemGroup>

--- a/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeaterDemo/TileRepeaterDemo.csproj
+++ b/Samples/TypeEditor/Dotnet/TileRepeater_Medium/TileRepeaterDemo/TileRepeaterDemo.csproj
@@ -9,7 +9,6 @@
     <UseTileRepeater>true</UseTileRepeater>
   </PropertyGroup>
 
-
 	<ItemGroup>
 	  <ProjectReference Include="..\TileRepeater.Data\TileRepeater.Data.csproj" />
 	</ItemGroup>

--- a/Templates/TypeEditor/src/TemplateSolutions/CS.CustomTypeEditor/NuGet.config
+++ b/Templates/TypeEditor/src/TemplateSolutions/CS.CustomTypeEditor/NuGet.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+
   <packageSources>
+    <clear/>
     <add key="WinFormsSdk" value=".\NuGet\BuildOut" />
   </packageSources>
   <disabledPackageSources />
@@ -8,5 +10,12 @@
     <packageSource key="WinFormsSdk">
       <package pattern="CustomControlLibrary.Package*" />
     </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*"  />
+    </packageSource>
+    <packageSource key="Local Nuget Feed">
+      <package pattern="*" />
+    </packageSource>
   </packageSourceMapping>
+
 </configuration>

--- a/Templates/TypeEditor/src/TemplateSolutions/VB.CustomTypeEditor/NuGet.config
+++ b/Templates/TypeEditor/src/TemplateSolutions/VB.CustomTypeEditor/NuGet.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+
   <packageSources>
+    <clear/>
     <add key="WinFormsSdk" value=".\NuGet\BuildOut" />
   </packageSources>
   <disabledPackageSources />
@@ -8,5 +10,12 @@
     <packageSource key="WinFormsSdk">
       <package pattern="CustomControlLibrary.Package*" />
     </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*"  />
+    </packageSource>
+    <packageSource key="Local Nuget Feed">
+      <package pattern="*" />
+    </packageSource>
   </packageSourceMapping>
+
 </configuration>

--- a/Templates/TypeEditor/src/Templates/Templates/CS.TypeEditor/NuGet.config
+++ b/Templates/TypeEditor/src/Templates/Templates/CS.TypeEditor/NuGet.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+
   <packageSources>
+    <clear/>
     <add key="WinFormsSdk" value=".\NuGet\BuildOut" />
   </packageSources>
   <disabledPackageSources />
@@ -8,5 +10,12 @@
     <packageSource key="WinFormsSdk">
       <package pattern="CustomControlLibrary.Package*" />
     </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*"  />
+    </packageSource>
+    <packageSource key="Local Nuget Feed">
+      <package pattern="*" />
+    </packageSource>
   </packageSourceMapping>
+
 </configuration>

--- a/Templates/TypeEditor/src/Templates/Templates/VB.TypeEditor/NuGet.config
+++ b/Templates/TypeEditor/src/Templates/Templates/VB.TypeEditor/NuGet.config
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
+
   <packageSources>
+    <clear/>
     <add key="WinFormsSdk" value=".\NuGet\BuildOut" />
   </packageSources>
   <disabledPackageSources />
@@ -8,5 +10,12 @@
     <packageSource key="WinFormsSdk">
       <package pattern="CustomControlLibrary.Package*" />
     </packageSource>
+    <packageSource key="nuget.org">
+      <package pattern="*"  />
+    </packageSource>
+    <packageSource key="Local Nuget Feed">
+      <package pattern="*" />
+    </packageSource>
   </packageSourceMapping>
+
 </configuration>


### PR DESCRIPTION
* Add additional definitions for non-specific NuGet packages to be found.
* Make sure, that no previously defined definitions are affecting the per-project NuGet definitions.
